### PR TITLE
Drop OpenEye from the CI Tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,20 +34,12 @@ jobs:
         python-version: ${{ matrix.cfg.python-version }}
         environment-file: devtools/conda-envs/test_env.yaml
 
-        channels: openeye,conda-forge/label/openff-toolkit_rc,conda-forge
+        channels: conda-forge
 
         activate-environment: test
         auto-update-conda: true
         auto-activate-base: false
         show-channel-urls: true
-
-    - name: License OpenEye
-      shell: bash -l {0}
-      run: |
-        echo "${SECRET_OE_LICENSE}" > ${OE_LICENSE}
-        python -c "from openeye import oechem; assert oechem.OEChemIsLicensed()"
-      env:
-        SECRET_OE_LICENSE: ${{ secrets.OE_LICENSE }}
 
     - name: Install Package
       shell: bash -l {0}

--- a/constructure/constructors.py
+++ b/constructure/constructors.py
@@ -268,7 +268,7 @@ class RDKitConstructor(Constructor):
             return "halogen"
 
         # Check for hetero
-        if attachment_atom.GetAtomicNum() in [7, 8]:
+        if attachment_atom.GetAtomicNum() in [7, 8, 15, 16]:
             return "hetero"
 
         # Check for alkyl
@@ -299,7 +299,7 @@ class RDKitConstructor(Constructor):
         return remove_duplicate_smiles(smiles)
 
 
-class OpenEyeConstructor(Constructor):
+class OpenEyeConstructor(Constructor):  # pragma: no cover
     """A class which provides methods for enumerating the possible attachments of
     substituents to different molecular scaffolds using the OpenEye toolkit."""
 
@@ -376,7 +376,7 @@ class OpenEyeConstructor(Constructor):
             return "halogen"
 
         # Check for hetero
-        if attachment_atom.GetAtomicNum() in [7, 8]:
+        if attachment_atom.GetAtomicNum() in [7, 8, 15, 16]:
             return "hetero"
 
         # Check for alkyl

--- a/constructure/tests/test_constructors.py
+++ b/constructure/tests/test_constructors.py
@@ -1,11 +1,19 @@
+import importlib
+
 import pytest
 
-from constructure.constructors import OpenEyeConstructor, RDKitConstructor
+from constructure.constructors import Constructor, OpenEyeConstructor, RDKitConstructor
 from constructure.scaffolds import Scaffold
 from constructure.tests import does_not_raise
 
+try:
+    importlib.import_module("openeye")
+    CONSTRUCTORS = [OpenEyeConstructor, RDKitConstructor]
+except ImportError:
+    CONSTRUCTORS = [RDKitConstructor]
 
-@pytest.mark.parametrize("constructor", [OpenEyeConstructor, RDKitConstructor])
+
+@pytest.mark.parametrize("constructor", CONSTRUCTORS)
 @pytest.mark.parametrize(
     "scaffold, expected",
     [
@@ -32,12 +40,12 @@ from constructure.tests import does_not_raise
         ),
     ],
 )
-def test_n_replaceable_groups(constructor, scaffold, expected):
+def test_n_replaceable_groups(constructor: Constructor, scaffold, expected):
     assert constructor.n_replaceable_groups(scaffold) == expected
 
 
-@pytest.mark.parametrize("constructor", [OpenEyeConstructor, RDKitConstructor])
-def test_attach_substituents(constructor):
+@pytest.mark.parametrize("constructor", CONSTRUCTORS)
+def test_attach_substituents(constructor: Constructor):
 
     from rdkit import Chem
 
@@ -54,7 +62,7 @@ def test_attach_substituents(constructor):
     assert smiles == "CC(Cl)c1ccccc1"
 
 
-@pytest.mark.parametrize("constructor", [OpenEyeConstructor, RDKitConstructor])
+@pytest.mark.parametrize("constructor", CONSTRUCTORS)
 @pytest.mark.parametrize(
     "substituent, expected",
     [
@@ -74,12 +82,12 @@ def test_attach_substituents(constructor):
         ("[R][Li]", None),
     ],
 )
-def test_classify_substituent(constructor, substituent, expected):
+def test_classify_substituent(constructor: Constructor, substituent, expected):
     assert constructor.classify_substituent(substituent) == expected
 
 
-@pytest.mark.parametrize("constructor", [OpenEyeConstructor, RDKitConstructor])
-def test_classify_substituent_error(constructor):
+@pytest.mark.parametrize("constructor", CONSTRUCTORS)
+def test_classify_substituent_error(constructor: Constructor):
 
     with pytest.raises(ValueError, match="The substituent C does not contain the "):
         constructor.classify_substituent("C")
@@ -130,11 +138,11 @@ def test_validate_substituents(substituents, expected_raises):
     )
 
     with expected_raises:
-        OpenEyeConstructor.validate_substituents(scaffold, substituents)
+        RDKitConstructor.validate_substituents(scaffold, substituents)
 
 
-@pytest.mark.parametrize("constructor", [OpenEyeConstructor, RDKitConstructor])
-def test_remove_duplicate_smiles(constructor):
+@pytest.mark.parametrize("constructor", CONSTRUCTORS)
+def test_remove_duplicate_smiles(constructor: Constructor):
 
     unique_smiles = constructor._remove_duplicate_smiles(
         ["C(Cl)(F)(Br)", "C(F)(Cl)(Br)"]
@@ -143,8 +151,8 @@ def test_remove_duplicate_smiles(constructor):
     assert len(unique_smiles) == 1
 
 
-@pytest.mark.parametrize("constructor", [OpenEyeConstructor, RDKitConstructor])
-def test_enumerate_combinations_combinatorial(constructor):
+@pytest.mark.parametrize("constructor", CONSTRUCTORS)
+def test_enumerate_combinations_combinatorial(constructor: Constructor):
 
     from rdkit import Chem
 

--- a/constructure/tests/utilities/test_openeye.py
+++ b/constructure/tests/utilities/test_openeye.py
@@ -9,6 +9,8 @@ from constructure.utilities.openeye import (
     smiles_to_image_grid,
 )
 
+pytest.importorskip("openeye.oechem")
+
 
 @requires_oe_package("oechem")
 def dummy_oe_function():

--- a/constructure/utilities/openeye.py
+++ b/constructure/utilities/openeye.py
@@ -13,7 +13,9 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
-def requires_oe_package(package_name: Literal["oechem", "oedepict"]):
+def requires_oe_package(
+    package_name: Literal["oechem", "oedepict"]
+):  # pragma: no cover
     """A decorator which checks that the required OpenEye package is installed
     and licensed.
 
@@ -21,8 +23,8 @@ def requires_oe_package(package_name: Literal["oechem", "oedepict"]):
         package_name: The name of the required OpenEye package.
     """
 
-    @requires_package(f"openeye.{package_name}")
     def inner_decorator(function):
+        @requires_package(f"openeye.{package_name}")
         @functools.wraps(function)
         def wrapper(*args, **kwargs):
 
@@ -50,7 +52,7 @@ def smiles_to_image_grid(
     cols: int = 8,
     cell_width: int = 200,
     cell_height: int = 200,
-):
+):  # pragma: no cover
     """Saves a list of SMILES patterns as an image of their corresponding 2D structures.
 
     Args:
@@ -92,7 +94,7 @@ def smiles_to_image_grid(
 
 
 @requires_oe_package("oechem")
-def remove_duplicate_smiles(smiles: List[str]) -> List[str]:
+def remove_duplicate_smiles(smiles: List[str]) -> List[str]:  # pragma: no cover
     """Returns the list of unique SMILES patterns in a specified list.
 
     Args:

--- a/constructure/utilities/utilities.py
+++ b/constructure/utilities/utilities.py
@@ -2,7 +2,6 @@ import functools
 import importlib
 
 _CONDA_INSTALLATION_COMMANDS = {
-    "openff.toolkit": "conda install -c conda-forge openff-toolkit",
     "openeye": "conda install -c openeye openeye-toolkits",
     "rdkit": "conda install -c conda-forge rdkit",
 }

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -1,6 +1,5 @@
 name: test
 channels:
-  - openeye
   - conda-forge
 dependencies:
 
@@ -9,8 +8,6 @@ dependencies:
 
     # --- Core ---
   - pydantic
-    # """ OpenEye """
-  - openeye-toolkits
     # """ RDKit """
   - rdkit
 
@@ -18,7 +15,6 @@ dependencies:
   - pytest
   - pytest-cov
   - codecov
-  - openff-toolkit
 
     # --- Developer ---
   - isort


### PR DESCRIPTION
## Description
This PR ensures that the CI no longer installs the OE packages, testing only the RDKit backend instead. OE tests may still be ran locally when OE is installed.

## Status
- [X] Ready to go