### PR TITLE
Add option to disable substituent validation

### DIFF
--- a/constructure/constructors.py
+++ b/constructure/constructors.py
@@ -143,6 +143,7 @@ class Constructor(abc.ABC):
         scaffold: Scaffold,
         substituents: Dict[int, List[str]],
         mode: Literal["combinatorial"] = "combinatorial",
+        validate: bool = True,
     ) -> List[str]:
         """Attempts to enumerate the possible ways of attaching a set of substituents to
         a specified scaffold.
@@ -159,13 +160,17 @@ class Constructor(abc.ABC):
                 the substituents to the scaffold. The number of these can grow large
                 for scaffolds with several R groups and multiple possible substituents
                 per R group.
+            validate: Whether to try and validate whether a substituent is suitable
+                for attachment to a scaffold. This check is crude and will allow
+                unphysical chemistry's to pass through.
 
         Returns
             A list of SMILES patterns representing the possible decorated scaffolds.
         """
 
         # Make sure the substituents are appropriate for the specified scaffold.
-        cls.validate_substituents(scaffold, substituents)
+        if validate:
+            cls.validate_substituents(scaffold, substituents)
 
         if mode == "combinatorial":
 

--- a/constructure/tests/test_constructors.py
+++ b/constructure/tests/test_constructors.py
@@ -171,3 +171,24 @@ def test_enumerate_combinations_combinatorial(constructor: Constructor):
     assert {"CCCC(O)CCC=O", "CCC(O)CCC=O", "CCC(O)CCC(C)=O", "CCCC(O)CCC(C)=O"} == {
         Chem.MolToSmiles(Chem.MolFromSmiles(smiles)) for smiles in enumerated_smiles
     }
+
+
+@pytest.mark.parametrize("constructor", CONSTRUCTORS)
+@pytest.mark.parametrize(
+    "validate, expected_raises",
+    [(False, None), (True, pytest.raises(ValueError, match="group only accepts "))],
+)
+def test_enumerate_combinations_validation(
+    constructor: Constructor, validate: bool, expected_raises
+):
+
+    if expected_raises is None:
+        expected_raises = does_not_raise()
+
+    scaffold = Scaffold(smiles="C([R1])", r_groups={1: ["alkyl"]})
+
+    with expected_raises:
+
+        constructor.enumerate_combinations(
+            scaffold=scaffold, substituents={1: ["[R]O"]}, validate=validate
+        )


### PR DESCRIPTION
## Description

This PR adds the (unadvisable) option to disable the scaffold-substituent compatibility validation check when enumerating combinations.

## Status
- [X] Ready to go