### PR TITLE
Validate substituents by R-group number

### DIFF
--- a/constructure/constructors.py
+++ b/constructure/constructors.py
@@ -99,8 +99,7 @@ class Constructor(abc.ABC):
 
         if len(set(expected_r_groups)) != len(expected_r_groups):
             r_group_str = ", ".join(sorted(f"R{i}" for i in expected_r_groups))
-            raise ValueError("Duplicate R-group values found in " +
-                             r_group_str)
+            raise ValueError("Duplicate R-group values found in " + r_group_str)
 
         missing_r_groups = {i for i in expected_r_groups if i not in substituents}
         missing_r_groups.update(i for i in substituents if len(substituents[i]) == 0)
@@ -236,13 +235,15 @@ class RDKitConstructor(Constructor):
     def get_replaceable_r_groups(cls, scaffold: Scaffold) -> List[int]:
         from rdkit import Chem
 
-        scaffold_smiles = re.sub(r"\(\[R(?P<num>[1-9])+]\)",
-                                 r"([\1*:\g<num>])",
-                                 scaffold.smiles)
+        scaffold_smiles = re.sub(
+            r"\(\[R(?P<num>[1-9])+]\)", r"([\1*:\g<num>])", scaffold.smiles
+        )
         scaffold_molecule = Chem.MolFromSmiles(scaffold_smiles)
-        numbers = [atom.GetAtomMapNum()
-                   for atom in scaffold_molecule.GetAtoms()
-                   if atom.GetAtomMapNum() != 0]
+        numbers = [
+            atom.GetAtomMapNum()
+            for atom in scaffold_molecule.GetAtoms()
+            if atom.GetAtomMapNum() != 0
+        ]
         return sorted(numbers)
 
     @classmethod
@@ -362,8 +363,11 @@ class OpenEyeConstructor(Constructor):  # pragma: no cover
 
         scaffold_molecule = oechem.OEMol()
         oechem.OESmilesToMol(scaffold_molecule, scaffold.smiles)
-        numbers = [atom.GetMapIdx() for atom in scaffold_molecule.GetAtoms()
-                   if atom.GetMapIdx() != 0]
+        numbers = [
+            atom.GetMapIdx()
+            for atom in scaffold_molecule.GetAtoms()
+            if atom.GetMapIdx() != 0
+        ]
         return sorted(numbers)
 
     @classmethod

--- a/constructure/tests/test_constructors.py
+++ b/constructure/tests/test_constructors.py
@@ -202,17 +202,35 @@ def test_remove_duplicate_smiles(constructor: Constructor):
 
 
 @pytest.mark.parametrize("constructor", CONSTRUCTORS)
-def test_enumerate_combinations_combinatorial(constructor: Constructor):
+@pytest.mark.parametrize(
+    "smiles, r_groups, substituents",
+    [
+        (
+            "C([R1])C(O)CC([R2])",
+            {1: ["alkyl"], 2: ["acyl"]},
+            {1: ["[R]C", "[R]CC"], 2: ["[R]C=O", "[R]C(=O)C"]},
+        ),
+        (
+            "C([R9])C(O)CC([R2])",
+            {9: ["alkyl"], 2: ["acyl"]},
+            {9: ["[R]C", "[R]CC"], 2: ["[R]C=O", "[R]C(=O)C"]},
+        ),
+    ],
+)
+def test_enumerate_combinations_combinatorial(
+    constructor: Constructor, smiles: str, r_groups: dict, substituents: dict
+):
 
     from rdkit import Chem
 
     scaffold = Scaffold(
-        smiles="C([R1])C(O)CC([R2])", r_groups={1: ["alkyl"], 2: ["acyl"]}
+        smiles=smiles,
+        r_groups=r_groups,
     )
 
     enumerated_smiles = constructor.enumerate_combinations(
         scaffold=scaffold,
-        substituents={1: ["[R]C", "[R]CC"], 2: ["[R]C=O", "[R]C(=O)C"]},
+        substituents=substituents,
         mode="combinatorial",
     )
 

--- a/constructure/tests/test_constructors.py
+++ b/constructure/tests/test_constructors.py
@@ -211,9 +211,9 @@ def test_remove_duplicate_smiles(constructor: Constructor):
             {1: ["[R]C", "[R]CC"], 2: ["[R]C=O", "[R]C(=O)C"]},
         ),
         (
-            "C([R9])C(O)CC([R2])",
-            {9: ["alkyl"], 2: ["acyl"]},
-            {9: ["[R]C", "[R]CC"], 2: ["[R]C=O", "[R]C(=O)C"]},
+            "C([R9])C(O)CC([R32])",
+            {9: ["alkyl"], 32: ["acyl"]},
+            {9: ["[R]C", "[R]CC"], 32: ["[R]C=O", "[R]C(=O)C"]},
         ),
     ],
 )

--- a/constructure/tests/test_constructors.py
+++ b/constructure/tests/test_constructors.py
@@ -75,7 +75,7 @@ def test_n_replaceable_groups(constructor: Constructor, scaffold, expected):
                 r_groups={i: ["hydrogen"] for i in (2, 3, 4, 7)},
             ),
             [2, 3, 4, 7],
-        )
+        ),
     ],
 )
 def test_get_replaceable_r_groups(constructor: Constructor, scaffold, expected):
@@ -180,18 +180,15 @@ def test_validate_substituents(substituents, expected_raises):
 
 
 def test_validate_replaceable_r_groups():
-    scaffold = Scaffold(smiles="C([R1])([R1])([R3])([R4])",
-                        r_groups={1: ["hydrogen"],
-                                  2: ["alkyl"],
-                                  3: ["aryl"],
-                                  4: ["halogen"]},)
+    scaffold = Scaffold(
+        smiles="C([R1])([R1])([R3])([R4])",
+        r_groups={1: ["hydrogen"], 2: ["alkyl"], 3: ["aryl"], 4: ["halogen"]},
+    )
     err = "Duplicate R-group values found"
     with pytest.raises(ValueError, match=err):
-        RDKitConstructor.validate_substituents(scaffold,
-                                               {1: ["[R][H]"],
-                                                2: ["[R]C"],
-                                                3: ["[R]c1ccccc1"],
-                                                4: ["[R]Cl"]})
+        RDKitConstructor.validate_substituents(
+            scaffold, {1: ["[R][H]"], 2: ["[R]C"], 3: ["[R]c1ccccc1"], 4: ["[R]Cl"]}
+        )
 
 
 @pytest.mark.parametrize("constructor", CONSTRUCTORS)


### PR DESCRIPTION
Fixes #7

## Description
Instead of converting R-group numbers to a consecutive list of numbers, take them at face value.

## Potential issues

- Some bright spark numbers their R-groups from 0. I don't currently check for this, but I can raise an error. This is not accounted for in the current code either.
- There is no validation check for duplicate R-groups when generating the Scaffold (instead, it's in generating the Constructor). I could add this, along with potentially checking for sufficient `r_groups` entries.